### PR TITLE
Taking into consideration the bottom inset of the safe area for the modal height

### DIFF
--- a/Source/DeckPresentationController.swift
+++ b/Source/DeckPresentationController.swift
@@ -81,7 +81,7 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
     private lazy var modalHeight: CGFloat = {
         guard let containerView = containerView else { return 0 }
 
-        let contentHeight: CGFloat
+        var contentHeight: CGFloat
         if  let navController = presentedViewController as? UINavigationController,
             let rootViewController = navController.viewControllers.first {
 
@@ -92,6 +92,11 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
 
             let presentedVCSize = presentedViewController.view.systemLayoutSizeFitting(CGSize(width: containerView.bounds.width, height: 0))
             contentHeight = presentedVCSize.height
+        }
+        
+        if #available(iOS 11, *) {
+            
+            contentHeight += containerView.safeAreaInsets.bottom
         }
 
         let fullHeight = containerView.bounds.height - (ManualLayout.presentingViewTopInset + Constants.insetForPresentedView)


### PR DESCRIPTION
# About

There was a layout bug occurring when presenting a modal in iPhone X because of the bottom inset in the safe area. This was causing the constraints in the modal view to break.

# How

Taking into consideration the bottom inset of the safe area has solved the issue.