### PR TITLE
Feature/expandable modal

### DIFF
--- a/DeckTransition.podspec
+++ b/DeckTransition.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name				= 'DeckTransition'
-  spec.version          = '2.0.4'
+  spec.version          = '2.1.0'
   spec.summary          = 'An attempt to recreate the iOS 10 now playing transition'
   spec.description      = <<-DESC
 						  DeckTransition is an attempt to recreate the iOS 10 Apple Music now playing and iMessage App Store transition.

--- a/DeckTransition.xcodeproj/project.pbxproj
+++ b/DeckTransition.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		E8B271641FD7E145009883B2 /* UIViewController+DeckTransitionViewControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B271631FD7E145009883B2 /* UIViewController+DeckTransitionViewControllerProtocol.swift */; };
 		E8B271661FD7E208009883B2 /* ScrollViewDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B271651FD7E208009883B2 /* ScrollViewDetector.swift */; };
 		E8B271681FD7E20F009883B2 /* ScrollViewUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B271671FD7E20F009883B2 /* ScrollViewUpdater.swift */; };
+		FCA4364D21512EA60034D38D /* DeckViewExpander.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCA4364C21512EA60034D38D /* DeckViewExpander.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -73,6 +74,7 @@
 		E8B271631FD7E145009883B2 /* UIViewController+DeckTransitionViewControllerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+DeckTransitionViewControllerProtocol.swift"; sourceTree = "<group>"; };
 		E8B271651FD7E208009883B2 /* ScrollViewDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewDetector.swift; sourceTree = "<group>"; };
 		E8B271671FD7E20F009883B2 /* ScrollViewUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewUpdater.swift; sourceTree = "<group>"; };
+		FCA4364C21512EA60034D38D /* DeckViewExpander.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeckViewExpander.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -116,6 +118,7 @@
 		D93F1C9A1EAEDB6E009A7474 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				FCA4364C21512EA60034D38D /* DeckViewExpander.swift */,
 				E8683D871F344793005C7E9A /* DeckSegue.swift */,
 				E8683D851F34478A005C7E9A /* DeckTransitioningDelegate.swift */,
 				E8683D891F34479E005C7E9A /* DeckPresentationController.swift */,
@@ -307,6 +310,7 @@
 				E87B47281F6E799D004AA6C7 /* Corner.swift in Sources */,
 				E87B47261F6E7983004AA6C7 /* CGRect+Corners.swift in Sources */,
 				E8683D881F344793005C7E9A /* DeckSegue.swift in Sources */,
+				FCA4364D21512EA60034D38D /* DeckViewExpander.swift in Sources */,
 				E8B271641FD7E145009883B2 /* UIViewController+DeckTransitionViewControllerProtocol.swift in Sources */,
 				E8B271681FD7E20F009883B2 /* ScrollViewUpdater.swift in Sources */,
 				E8473CC81F698D3700852FE3 /* ManualLayout.swift in Sources */,

--- a/Source/DeckPresentationController.swift
+++ b/Source/DeckPresentationController.swift
@@ -726,9 +726,9 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
 
 	func expandView() {
 
-		presentedView?.constraints
-			.filter({ $0.firstItem === presentedView && $0.firstAttribute == .height })
-			.forEach({ $0.constant = containerView?.frame.height ?? 0 })
+		presentedViewController.view.constraints
+			.filter({ $0.firstItem === presentedViewController.view && $0.firstAttribute == .height })
+			.forEach({ $0.constant = containerView?.frame.height ?? UIScreen.main.bounds.height })
 
 		UIView.animate(withDuration: Constants.defaultAnimationDuration,
 					   delay: 0,
@@ -738,8 +738,8 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
 
 	func compressView() {
 
-		presentedView?.constraints
-			.filter({ $0.firstItem === presentedView && $0.firstAttribute == .height })
+		presentedViewController.view.constraints
+			.filter({ $0.firstItem === presentedViewController.view && $0.firstAttribute == .height })
 			.forEach({ $0.constant = modalHeight })
 
 		UIView.animate(withDuration: Constants.defaultAnimationDuration,

--- a/Source/DeckPresentationController.swift
+++ b/Source/DeckPresentationController.swift
@@ -724,6 +724,8 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
         return true
     }
 
+	// MARK: - DeckViewExpander conformance
+
 	func expandView() {
 
 		animateHeight(to: containerView?.frame.height ?? UIScreen.main.bounds.height)

--- a/Source/DeckPresentationController.swift
+++ b/Source/DeckPresentationController.swift
@@ -726,21 +726,19 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
 
 	func expandView() {
 
-		presentedViewController.view.constraints
-			.filter({ $0.firstItem === presentedViewController.view && $0.firstAttribute == .height })
-			.forEach({ $0.constant = containerView?.frame.height ?? UIScreen.main.bounds.height })
-
-		UIView.animate(withDuration: Constants.defaultAnimationDuration,
-					   delay: 0,
-					   options: .curveEaseInOut,
-					   animations: containerView?.layoutIfNeeded ?? presentedViewController.view.layoutIfNeeded)
+		animateHeight(to: containerView?.frame.height ?? UIScreen.main.bounds.height)
 	}
 
 	func compressView() {
 
+		animateHeight(to: modalHeight)
+	}
+
+	private func animateHeight(to height: CGFloat) {
+
 		presentedViewController.view.constraints
 			.filter({ $0.firstItem === presentedViewController.view && $0.firstAttribute == .height })
-			.forEach({ $0.constant = modalHeight })
+			.forEach({ $0.constant = height })
 
 		UIView.animate(withDuration: Constants.defaultAnimationDuration,
 					   delay: 0,

--- a/Source/DeckViewExpander.swift
+++ b/Source/DeckViewExpander.swift
@@ -1,0 +1,14 @@
+//
+//  DeckViewExpander.swift
+//  DeckTransition
+//
+//  Created by Rodrigo Kreutz on 18/09/2018.
+//
+
+import Foundation
+
+public protocol DeckViewExpander {
+
+	func expandView()
+	func compressView()
+}

--- a/Source/DeckViewExpander.swift
+++ b/Source/DeckViewExpander.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol DeckViewExpander {
+public protocol DeckViewExpander: AnyObject {
 
 	func expandView()
 	func compressView()

--- a/Source/Extensions/UIViewController+IsPresentedWithDeck.swift
+++ b/Source/Extensions/UIViewController+IsPresentedWithDeck.swift
@@ -17,5 +17,9 @@ extension UIViewController {
             && modalPresentationStyle == .custom
             && presentingViewController != nil
     }
-    
+
+	public var deckViewExpander: DeckViewExpander? {
+
+		return presentationController as? DeckViewExpander
+	}
 }


### PR DESCRIPTION
# About
This PR implements the expandable feature on deck modals.

# How
To do so, we had to programatically add the constraints we need, so later on we can adjust them to expand/compress accordingly. To expand/collapse the view, was created a protocol `DeckViewExpander` which has the `collapseView` and `expandView` which are responsible for collapsing/expanding the deck view respectively. `DeckPresentationController` implements this protocol, since it holds all the info we need to be able to collapse/expand the view. Since the `DeckPresentationController` is not visible outside the library - the library was originally designed to not expose any of the logic of the transition, which I believe is a good thing so we don't mess with the internal behaviours outside of the library - we've created a computed property in an `UIViewController` extension which returns the `DeckViewExpander` - the `DeckPresentationController` casted as `DeckViewExpander` - which is all we need to collapse/expand the view.
So it would look like this to expand and collapse a modal view:
```swift
viewController.deckViewExpander?.expandView()
viewController.deckViewExpander?.collapseView()
```

# Visual implementation
![sep-18-2018 14-16-35](https://user-images.githubusercontent.com/39093828/45690084-7c794b80-bb4d-11e8-8a76-43fae5e3cf37.gif)
