### PR TITLE
Fixing issues regarding the constraints' priorities when expanding/compressing modals

### DIFF
--- a/DeckTransition.podspec
+++ b/DeckTransition.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name				= 'DeckTransition'
-  spec.version          = '2.1.0'
+  spec.version          = '2.1.1'
   spec.summary          = 'An attempt to recreate the iOS 10 now playing transition'
   spec.description      = <<-DESC
 						  DeckTransition is an attempt to recreate the iOS 10 Apple Music now playing and iMessage App Store transition.

--- a/Source/DeckPresentationController.swift
+++ b/Source/DeckPresentationController.swift
@@ -287,12 +287,12 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
 		/// The height priority should be high enough so it can take effect, but should be smaller than all other constraints so we can
 		/// guarantee it won't be bigger than what the container view permits
 		let heightConstraint = presentedViewController.view.heightAnchor.constraint(equalToConstant: modalHeight)
-		heightConstraint.priority = .defaultHigh
+		heightConstraint.priority = UILayoutPriority(998)
 
 		/// The bottom constraint can't be required because when dismissing the view it conflicts with the autoresizing constraints,
 		/// but its priority should be higher than the height priority so the height doesn't grow out of the bounds of the container view.
 		let bottomConstraint = presentedViewController.view.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
-		bottomConstraint.priority = UILayoutPriority(900)
+		bottomConstraint.priority = UILayoutPriority(999)
 
 		NSLayoutConstraint.activate([heightConstraint, bottomConstraint])
 


### PR DESCRIPTION
# About

This PR fixes an issue that has been reported on iPhone 8 Plus.

# How

Basically it seemed that the priority of the height constraint wasn't high enough, so I've increased it's priority. Tested on iPhone 8, iPhone 8 Plus, iPhone X, iPhone SE (simulators).