### PR TITLE
Adding a method to the DeckViewExpander which enables custom heights for the modal

### DIFF
--- a/DeckTransition.podspec
+++ b/DeckTransition.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name				= 'DeckTransition'
-  spec.version          = '2.1.1'
+  spec.version          = '2.2.0'
   spec.summary          = 'An attempt to recreate the iOS 10 now playing transition'
   spec.description      = <<-DESC
 						  DeckTransition is an attempt to recreate the iOS 10 Apple Music now playing and iMessage App Store transition.

--- a/Source/DeckPresentationController.swift
+++ b/Source/DeckPresentationController.swift
@@ -736,6 +736,11 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
 		animateHeight(to: modalHeight)
 	}
 
+	func setModalHeight(to height: CGFloat) {
+
+		animateHeight(to: height)
+	}
+
 	private func animateHeight(to height: CGFloat) {
 
 		presentedViewController.view.constraints

--- a/Source/DeckViewExpander.swift
+++ b/Source/DeckViewExpander.swift
@@ -9,6 +9,14 @@ import Foundation
 
 public protocol DeckViewExpander: AnyObject {
 
+	/// Expands the modal to the screen's height
 	func expandView()
+
+	/// Compresses the modal to it's initial height, which is determined by the internal constraints of the view
 	func compressView()
+
+	/// Sets the height of the modal view to a determined height
+	///
+	/// - Parameter height: the new height for the modal view, it won't grow bigger than the screen size though
+	func setModalHeight(to height: CGFloat)
 }


### PR DESCRIPTION
# About
This PR implements an extra method in the `DeckViewExpander` which enables it to set a custom height to the modal, instead of only the compressed height and the full height.